### PR TITLE
DDCE-4423: Upgrade to Gatling 3.6.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "digital-tariffs-ruling-performance-tests",
     version := "0.1.0",
-    scalaVersion := "2.13.10",
+    scalaVersion := "2.13.11",
     //implicitConversions & postfixOps are Gatling recommended -language settings
     scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps"),
     // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,15 +1,15 @@
-import sbt._
+import sbt.*
 
 object Dependencies {
 
-  private val gatlingVersion = "3.5.1"
+  private val gatlingVersion: String = "3.6.1"
 
-  private val test               = Seq(
+  private val test: Seq[ModuleID] = Seq(
     "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion,
     "io.gatling"            % "gatling-test-framework"    % gatlingVersion,
-    "uk.gov.hmrc"          %% "performance-test-runner"   % "5.3.0"
+    "uk.gov.hmrc"          %% "performance-test-runner"   % "5.6.0"
   ).map(_ % Test)
 
-  def apply(): Seq[sbt.ModuleID] = test
+  def apply(): Seq[sbt.ModuleID]  = test
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,8 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build" % "3.8.0")
-addSbtPlugin("io.gatling"          % "gatling-sbt"    % "4.2.4")
+addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build" % "3.9.0")
+addSbtPlugin("io.gatling"          % "gatling-sbt"    % "4.1.5")
 addSbtPlugin("com.timushev.sbt"    % "sbt-updates"    % "0.6.3")
 addSbtPlugin("org.scalameta"       % "sbt-scalafmt"   % "2.5.0")
 addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle" % "1.5.1")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -9,7 +9,7 @@
     <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
         <parameters>
             <parameter name="header"><![CDATA[/*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 # The baseUrl can be overridden in services-local.conf. See that file for more information
 # That file is ignored when the test is not run locally. The default is false
+
 runLocal = false
 
 perftest {

--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/services-local.conf
+++ b/src/test/resources/services-local.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
 
 services {
 
-  binding-tariff-ruling-frontend.port = 1234
+  binding-tariff-ruling-frontend.port = 9586
 
 }

--- a/src/test/resources/services.conf
+++ b/src/test/resources/services.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/perftests/digitaltariffs/Configuration.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/digitaltariffs/Configuration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/perftests/digitaltariffs/rulingui/RulingUiRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/digitaltariffs/rulingui/RulingUiRequests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/perftests/digitaltariffs/rulingui/RulingUiSimulation.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/digitaltariffs/rulingui/RulingUiSimulation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### DDCE-4421: Upgrade to Gatling 3.6.1

- Branch ran on staging - https://performance.tools.staging.tax.service.gov.uk/job/digital-tariffs-ruling-performance-tests/44/
- Upgraded to Scala 2.13.11
